### PR TITLE
fixed: byte[] deserialization

### DIFF
--- a/java/smart-flows-sdk/src/main/java/xpertdoc/smartflows/client/JSON.java
+++ b/java/smart-flows-sdk/src/main/java/xpertdoc/smartflows/client/JSON.java
@@ -15,20 +15,23 @@ package xpertdoc.smartflows.client;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import com.google.gson.JsonElement;
 import io.gsonfire.GsonFireBuilder;
-import io.gsonfire.TypeSelector;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 
-import xpertdoc.smartflows.client.model.*;
-
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
@@ -37,7 +40,6 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Date;
 import java.util.Map;
-import java.util.HashMap;
 
 public class JSON {
     private Gson gson;
@@ -75,6 +77,7 @@ public class JSON {
             .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
             .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
+            .registerTypeAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())
             .create();
     }
 
@@ -359,4 +362,13 @@ public class JSON {
         return this;
     }
 
+    public static class ByteArrayToBase64TypeAdapter implements JsonSerializer<byte[]>, JsonDeserializer<byte[]> {
+        public byte[] deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            return DatatypeConverter.parseBase64Binary(json.getAsString());
+        }
+
+        public JsonElement serialize(byte[] src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(DatatypeConverter.printBase64Binary(src));
+        }
+    }
 }


### PR DESCRIPTION
The Smart Flows server encodes byte[] as base64 strings, but the client's default deserializer expects it to start with [ instead of been a String. Adding a JsonDeserializer for byte[] solves the problem
